### PR TITLE
copypbport was setting source port and not destination port

### DIFF
--- a/src/main/java/com/basho/proserv/datamigrator/Main.java
+++ b/src/main/java/com/basho/proserv/datamigrator/Main.java
@@ -185,7 +185,7 @@ public class Main {
 		// Destination PB port
 		if (cmd.hasOption("copypbport")) {
 			try {
-				config.setPort(Integer.parseInt(cmd.getOptionValue("copypbport")));
+				config.setDestinationPort(Integer.parseInt(cmd.getOptionValue("copypbport")));
 			} catch (NumberFormatException e) {
 				System.out.println("Destination PB Port (copypbport) argument is not an integer.");
 				System.exit(1);


### PR DESCRIPTION
Before this fix, I wasn't able to use the copy feature when source and destination riak clusters used different PB ports.